### PR TITLE
feat: Make world map fit parent component

### DIFF
--- a/public/index.css
+++ b/public/index.css
@@ -1,0 +1,3 @@
+html, body, #root, #root>div {
+  height: 100%
+}

--- a/public/index.html
+++ b/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="stylesheet" href="./index.css" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import './App.css';
 import Home from './pages/Home';
 

--- a/src/components/EarthGlobe.tsx
+++ b/src/components/EarthGlobe.tsx
@@ -1,4 +1,4 @@
-import { geoEqualEarth, geoPath, GeoProjection } from 'd3-geo';
+import { geoMercator, geoPath, GeoProjection } from 'd3-geo';
 import { FeatureCollection, GeoJsonProperties, Geometry } from 'geojson';
 import React from 'react';
 import { WorldAtlas } from 'topojson';
@@ -7,20 +7,21 @@ import { v4 as uuidv4 } from 'uuid';
 
 type EarthGlobeProps = {
   worldAtlas: WorldAtlas;
+  width: number;
+  height: number;
 };
 
 type EarthGlobeState = {
-  countries: FeatureCollection<Geometry, GeoJsonProperties> | null;
+  countries: FeatureCollection<Geometry, GeoJsonProperties>;
   earthGlobeSvg: React.RefObject<SVGElement>;
-};
+}; // test commit
 
 export default class EarthGlobe extends React.Component<
   EarthGlobeProps,
   EarthGlobeState
 > {
-  private scale: number;
-  private cx: number;
-  private cy: number;
+  private width: number;
+  private height: number;
   private projection: GeoProjection;
 
   constructor(props: EarthGlobeProps) {
@@ -33,36 +34,29 @@ export default class EarthGlobe extends React.Component<
       earthGlobeSvg: React.createRef(),
     };
 
-    this.scale = 200;
-    this.cx = 400;
-    this.cy = 150;
-    this.projection = geoEqualEarth()
-      .scale(this.scale)
-      .translate([this.cx, this.cy])
-      .rotate([0, 0]);
+    this.width = window.innerWidth;
+    this.height = window.innerHeight;
+    this.projection = geoMercator().fitSize(
+      [this.width, this.height],
+      this.state.countries
+    );
   }
 
   render() {
     return (
-      <>
-        <svg
-          width={this.scale * 3}
-          height={this.scale * 3}
-          viewBox="0 0 800 450"
-        >
-          <g>
-            {this.state.countries &&
-              this.state.countries.features.map(f => {
-                return (
-                  <path
-                    key={uuidv4()}
-                    d={geoPath().projection(this.projection)(f) as string}
-                  />
-                );
-              })}
-          </g>
-        </svg>
-      </>
+      <svg width={this.width} height={this.height}>
+        <g>
+          {this.state.countries &&
+            this.state.countries.features.map(f => {
+              return (
+                <path
+                  key={uuidv4()}
+                  d={geoPath().projection(this.projection)(f) as string}
+                />
+              );
+            })}
+        </g>
+      </svg>
     );
   }
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -20,7 +20,13 @@ const Home = (): JSX.Element => {
       });
   }, []);
 
-  return <>{geographies && <EarthGlobe worldAtlas={geographies} />}</>;
+  return (
+    <>
+      {geographies && (
+        <EarthGlobe worldAtlas={geographies} width={100} height={100} />
+      )}
+    </>
+  );
 };
 
 export default Home;


### PR DESCRIPTION
## Scope

Make the world map fit its parent component.

Closes [SC-31](https://app.shortcut.com/broncos/story/31/make-world-map-fit-parent-component).

## Screenshots

**Before:**


<img width="1432" alt="image" src="https://github.com/rudyzac/dyno-globe/assets/46543175/40c20f67-8902-4b41-80a7-9571b1289de4">


**After:**


<img width="1434" alt="image" src="https://github.com/rudyzac/dyno-globe/assets/46543175/15897f18-2be6-40c5-8d21-53d28e3ffd2e">